### PR TITLE
Update for versions in latest alpine image

### DIFF
--- a/words/Dockerfile
+++ b/words/Dockerfile
@@ -20,7 +20,7 @@ FROM alpine:edge
 ENV LANG C.UTF-8
 ENV JAVA_HOME /usr/lib/jvm/java-1.8-openjdk/jre
 ENV PATH $PATH:/usr/lib/jvm/java-1.8-openjdk/jre/bin:/usr/lib/jvm/java-1.8-openjdk/bin
-RUN apk add --no-cache openjdk8-jre="8.151.12-r0" && rm usr/lib/libgif.so.7.0.0 usr/lib/libtasn1.so.6.5.4
+RUN apk add --no-cache openjdk8-jre="8.161.12-r0" && rm usr/lib/libgif.so.7.0.0 usr/lib/libtasn1.so.6.5.5
 
 ENTRYPOINT ["java", "-Xmx8m", "-Xms8m", "-jar", "./target/words.jar"]
 EXPOSE 8080


### PR DESCRIPTION
The version of Java and the asn1 library version don't match currently
and the Dockerfile build breaks without this change.

Signed-off-by: Phil Estes <estesp@gmail.com>