### PR TITLE
Fix cache bug (obsolete, replaced by #19)

### DIFF
--- a/web/dispatcher.go
+++ b/web/dispatcher.go
@@ -55,8 +55,8 @@ func copy(url, ip string, w http.ResponseWriter) error {
 	}
 
 	for header, values := range resp.Header {
-        for _, value := range values {
-            w.Header().Add(header, value)
+		for _, value := range values {
+			w.Header().Add(header, value)
 		}
 	}
 	w.Header().Set("source", ip)

--- a/web/dispatcher.go
+++ b/web/dispatcher.go
@@ -54,6 +54,11 @@ func copy(url, ip string, w http.ResponseWriter) error {
 		return err
 	}
 
+	for header, values := range resp.Header {
+        for _, value := range values {
+            w.Header().Add(header, value)
+		}
+	}
 	w.Header().Set("source", ip)
 
 	buf, err := ioutil.ReadAll(resp.Body)

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -9,22 +9,26 @@ lab.controller('LabCtrl', function ($scope, $http, $timeout) {
   $scope.adjective2 = "";
   $scope.verb = "";
 
-  getWord($http, $timeout, '/words/noun', function(resp) {
-    $scope.noun1 = word(resp);
+  getWord($http, $timeout, '/words/noun?n=1', function(resp1) {
+    $scope.noun1 = word(resp1);
   });
-  getWord($http, $timeout, '/words/noun', function(resp) {
-    $scope.noun2 = word(resp);
-  });
-  getWord($http, $timeout, '/words/adjective', function(resp) {
+
+  getWord($http, $timeout, '/words/adjective?a=1', function(resp) {
     var adj = word(resp);
     adj.word = adj.word.charAt(0).toUpperCase() + adj.word.substr(1)
     $scope.adjective1 = adj;
   });
-  getWord($http, $timeout, '/words/adjective', function(resp) {
-    $scope.adjective2 = word(resp);
-  });
+
   getWord($http, $timeout, '/words/verb', function(resp) {
     $scope.verb = word(resp);
+  });
+
+  getWord($http, $timeout, '/words/noun?n=2', function(resp2) {
+    $scope.noun2 = word(resp2);
+  });
+
+  getWord($http, $timeout, '/words/adjective?n=2', function(resp) {
+    $scope.adjective2 = word(resp);
   });
 });
 

--- a/words/src/main/java/Main.java
+++ b/words/src/main/java/Main.java
@@ -42,7 +42,11 @@ public class Main {
             byte[] bytes = response.getBytes(Charsets.UTF_8);
 
             System.out.println(response);
+            
             t.getResponseHeaders().add("content-type", "application/json; charset=utf-8");
+            t.getResponseHeaders().add("cache-control", "private, no-cache, no-store, must-revalidate, max-age=0");
+            t.getResponseHeaders().add("pragma", "no-cache");
+
             t.sendResponseHeaders(200, bytes.length);
 
             try (OutputStream os = t.getResponseBody()) {

--- a/words/src/main/java/Main.java
+++ b/words/src/main/java/Main.java
@@ -14,9 +14,9 @@ public class Main {
         Class.forName("org.postgresql.Driver");
 
         HttpServer server = HttpServer.create(new InetSocketAddress(8080), 0);
-        server.createContext("/noun", handler(Suppliers.memoize(() -> randomWord("nouns"))));
-        server.createContext("/verb", handler(Suppliers.memoize(() -> randomWord("verbs"))));
-        server.createContext("/adjective", handler(Suppliers.memoize(() -> randomWord("adjectives"))));
+        server.createContext("/noun", handler(() -> randomWord("nouns")));
+        server.createContext("/verb", handler(() -> randomWord("verbs")));
+        server.createContext("/adjective", handler(() -> randomWord("adjectives")));
         server.start();
     }
 


### PR DESCRIPTION
This fixes #8 (and more) by doing a few things:

- Adds header passthrough to the go dispatcher
- Adds query parameters to trick Safari (disgusting workaround but nothing else works!)
- Adds cache headers to the Java API
- No `Suppliers.memoize()` to prevent caching of the response

The latter is needed when scaling down the API to 1 or 2 containers. Should 2 requests hit the same container, the same word is returned.