### PR TITLE
Update web golang Dockerfile to support multi-platform

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,11 +1,11 @@
 # BUILD
-FROM golang:1.9.1-alpine3.6 as builder
+FROM golang:alpine as builder
 
 COPY dispatcher.go .
 RUN go build dispatcher.go
 
 # RUN
-FROM alpine:edge
+FROM alpine
 
 EXPOSE 80
 CMD ["/dispatcher"]


### PR DESCRIPTION
Builds will fail on arm64 unless we update to newer golang and alpine images. I didn't see the need to pin image versions for a simple ~60 line example.