### PR TITLE
updating java build for multi-platform

### DIFF
--- a/words/Dockerfile
+++ b/words/Dockerfile
@@ -1,11 +1,5 @@
 # BUILD
-FROM openjdk:8u171-jdk-alpine as build
-
-RUN MAVEN_VERSION=3.5.0 \
- && cd /usr/share \
- && wget http://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz -O - | tar xzf - \
- && mv /usr/share/apache-maven-$MAVEN_VERSION /usr/share/maven \
- && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+FROM maven:adoptopenjdk as build
 
 WORKDIR /home/lab
 
@@ -16,7 +10,7 @@ COPY src ./src
 RUN mvn verify
 
 # RUN
-FROM openjdk:8u171-jre-alpine
+FROM adoptopenjdk:8-jre
 
 ENTRYPOINT ["java", "-Xmx8m", "-Xms8m", "-jar", "/app/words.jar"]
 EXPOSE 8080


### PR DESCRIPTION
Also switching to easier maven images, and removing some version requirements for longer evergreen support.