### PR TITLE
"pull image if not present" solves failing kube deployment on M1

### DIFF
--- a/kube-deployment.yml
+++ b/kube-deployment.yml
@@ -31,6 +31,7 @@ spec:
       containers:
       - name: db
         image: dockersamples/k8s-wordsmith-db
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 5432
           name: db
@@ -69,6 +70,7 @@ spec:
       containers:
       - name: words
         image: dockersamples/k8s-wordsmith-api
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
           name: api
@@ -106,6 +108,7 @@ spec:
       containers:
       - name: web
         image: dockersamples/k8s-wordsmith-web
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
           name: words-web

--- a/kube-deployment.yml
+++ b/kube-deployment.yml
@@ -31,7 +31,7 @@ spec:
       containers:
       - name: db
         image: dockersamples/k8s-wordsmith-db
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Never
         ports:
         - containerPort: 5432
           name: db
@@ -70,7 +70,7 @@ spec:
       containers:
       - name: words
         image: dockersamples/k8s-wordsmith-api
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Never
         ports:
         - containerPort: 8080
           name: api
@@ -108,7 +108,7 @@ spec:
       containers:
       - name: web
         image: dockersamples/k8s-wordsmith-web
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Never
         ports:
         - containerPort: 80
           name: words-web


### PR DESCRIPTION
images on docker hub only support linux/amd64 - these images don't work with Docker Mac for Apple Silicon
you need to provide/build linux/arm64 images BEFORE you apply kube-deployment.yml
to stop kubernetes pulling amd64 images from docker hub I've added "imagepullPolicy: IfNotPresent".
this way you can build arm64 images first and then deploy them to kubernetes.
"Never" would also be an option but would then require everybody to build the images first.
so I went for "IfNotPresent" which at least for amd64 users leaves the convenience untouched to pull ready build images