### PR TITLE
Change service type to deploy on local

### DIFF
--- a/k8s-manifests/api.yaml
+++ b/k8s-manifests/api.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     app: api
 spec:
-  replicas: 5
+  replicas: 3
   selector:
     matchLabels:
       app: api

--- a/k8s-manifests/web.yaml
+++ b/k8s-manifests/web.yaml
@@ -11,7 +11,7 @@ spec:
       name: web
   selector:
     app: web
-  type: LoadBalancer
+  type: ClusterIP
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
To deploy on local would be more useful to use ClusterIP, it is extensiblely supported in cluster's as kind, minikube, and so on.