### PR TITLE
Remove the min and max heap size JVM args

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -10,5 +10,5 @@ RUN mvn verify
 FROM --platform=${TARGETPLATFORM} amazoncorretto:20
 WORKDIR /usr/local/app
 COPY --from=build /usr/local/app/target .
-ENTRYPOINT ["java", "-Xmx8m", "-Xms8m", "-jar", "/usr/local/app/words.jar"]
+ENTRYPOINT ["java", "-jar", "/usr/local/app/words.jar"]
 EXPOSE 8080


### PR DESCRIPTION
Fixes #53 

Removing the min & max heap size JVM args will cause the application deployment to fallback to default values.